### PR TITLE
patch: fix build error "[vite-plugin-top-level-await] Bindings not found"

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,6 @@ import { dependencies } from './package.json';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
-import topLevelAwait from 'vite-plugin-top-level-await';
 
 // dependencies that exist anywhere
 const vendor = [
@@ -37,6 +36,11 @@ function renderChunks(deps: Record<string, string>) {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  esbuild: {
+    supported: {
+      'top-level-await': true //browsers can handle top-level-await features
+    },
+  },
   plugins: [
     react(),
     visualizer({
@@ -44,12 +48,9 @@ export default defineConfig({
       gzipSize: true,
       brotliSize: true
     }),
-    topLevelAwait({
-      promiseExportName: '__tla',
-      promiseImportName: i => `__tla_${i}`
-    })
   ],
   build: {
+    target: 'esnext',
     chunkSizeWarningLimit: 3000,
     rollupOptions: {
       output: {


### PR DESCRIPTION
top-level await is supported by current browser, we may just skip this plugin.

(I install the dependencies with pnpm instead of npm, not sure if it is related)