### PR TITLE
feat(backend-golang): add debug mode checker

### DIFF
--- a/backend-golang/utils.go
+++ b/backend-golang/utils.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -51,6 +52,14 @@ func CmdHelper(hideWindow bool, args ...string) (*exec.Cmd, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	//go:custom_build windows cmd.SysProcAttr.HideWindow = hideWindow
 	return cmd, nil
+}
+
+func IsDebugMode() bool {
+	info, ok := debug.ReadBuildInfo()
+	// In Makefile, "-ldflags '-s -w'" is added in wails build phase.
+	containLinkerFlags := strings.Contains(info.String(), "-ldflags")
+	isDebugMode := ok && !containLinkerFlags
+	return isDebugMode
 }
 
 func Cmd(args ...string) (string, error) {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"runtime/debug"
 	"strings"
 
 	backend "rwkv-runner/backend-golang"
@@ -71,7 +70,7 @@ func main() {
 	app := backend.NewApp()
 	app.Dev = true
 
-	if buildInfo, ok := debug.ReadBuildInfo(); !ok || strings.Contains(buildInfo.String(), "-ldflags") {
+	if !backend.IsDebugMode() {
 		app.Dev = false
 
 		backend.CopyEmbed(assets)


### PR DESCRIPTION
我发现在 macOS debug 模式下，Runner 寻找 backend-python 的路径有错误

我准备在添加完该函数后根据 debug 环境与否判断一下正确的执行路径路径

```go
case "darwin":
	ex, err := os.Executable()
	if err != nil {
		return "", err
	}
	exDir := filepath.Dir(ex) + "/../../../"
	cmd := exec.Command("osascript", "-e", `tell application "Terminal" to do script "`+"cd "+exDir+" && "+strings.Join(args, " ")+`"`)
	err = cmd.Start()
	if err != nil {
		return "", err
	}
	cmd.Wait()
return "", nil
```