### PR TITLE
Optimize Dockerfile for smaller image size and faster build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,23 +16,23 @@ FROM nvidia/cuda:11.6.1-devel-ubuntu20.04 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && \
-    apt install -yq git curl wget build-essential ninja-build aria2 jq software-properties-common
-
-RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+RUN apt-get update && \
+    apt-get install -yq git curl wget build-essential ninja-build aria2 jq software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt install -y g++-11 python3.10 python3.10-distutils python3.10-dev && \
-    curl -sS http://mirrors.aliyun.com/pypi/get-pip.py | python3.10
+    apt-get install -y g++-11 python3.10 python3.10-distutils python3.10-dev && \
+    curl -sS http://mirrors.aliyun.com/pypi/get-pip.py | python3.10 && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN python3.10 -m pip install cmake
+RUN python3.10 -m pip install --no-cache-dir cmake
 
 FROM runtime AS librwkv
 
 WORKDIR /app
 
-RUN git clone https://github.com/RWKV/rwkv.cpp.git && \
+RUN git clone --depth 1 https://github.com/RWKV/rwkv.cpp.git && \
     cd rwkv.cpp && \
-    git submodule update --init --recursive && \
+    git submodule update --init --recursive --depth=1 && \
     mkdir -p build && \
     cd build && \
     cmake -G Ninja .. && \
@@ -44,7 +44,7 @@ WORKDIR /app
 
 COPY ./backend-python/requirements.txt ./backend-python/requirements.txt
 
-RUN python3.10 -m pip install --quiet -r ./backend-python/requirements.txt
+RUN python3.10 -m pip install --no-cache-dir --quiet -r ./backend-python/requirements.txt
 
 COPY . .
 COPY --from=frontend /app/frontend/dist /app/frontend/dist


### PR DESCRIPTION
Consolidate apt commands, use shallow git clone, and prevent cache files
from being stored in the image. These changes reduce the final image
size from 12.9GB to 10.1GB (21.7% reduction).

The optimizations include:
- Replace apt with apt-get following container best practices
- Merge multiple apt commands into a single instruction to reduce layers
- Clean up apt cache with `rm -rf /var/lib/apt/lists/*` to reduce size
- Use `--no-cache-dir` flag with pip to prevent caching
- Use shallow `git clone` with `--depth 1` for faster downloads
- Also apply git shallow submodule initialization with `--depth=1`

Image size reduced by 2.8GB, based on `docker images` output:

    REPOSITORY       TAG        IMAGE ID       CREATED          SIZE
    rwkv-runner      after      b9f5f7cba3dd   36 minutes ago   10.1GB
    rwkv-runner      before     4fc66df1e9b8   50 minutes ago   12.9GB

These changes follow Docker best practices by reducing layer count,
removing unnecessary files that would otherwise be stored in the image,
and improving CI efficiency, storage usage, and deployment speed in
production environments.
